### PR TITLE
ユーザー詳細ページの作成

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -29,9 +29,9 @@ class ImageUploader < CarrierWave::Uploader::Base
   # end
 
   # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
+  version :thumb do
+    process resize_to_fill: [150, 150]
+  end
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:

--- a/app/views/posts/_post_form.html.slim
+++ b/app/views/posts/_post_form.html.slim
@@ -4,7 +4,7 @@
     = f.file_field :photoes, multiple: true, class: 'form-control mb-1'
     - if action_name == 'edit'
       - @post.images.each do |img|
-        = image_tag img.photo.url, width: '100'
+        = image_tag img.photo.url(:thumb), width: '100'
   .form-group
     = f.label :body, t('activerecord.models.posts.body'), class: 'bmd-label-floating"'
     = f.text_field :body, value: @post&.body, class: 'form-control'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -17,7 +17,7 @@ header#header
                           {path: new_post_path, icon: 'image', title: '新規投稿作成'},
                           {path: '#', icon: 'comments', title: 'チャットルームへ'},
                           {path: '#', icon: 'heart', title: 'あなたへのお知らせ'},
-                          {path: '#', icon: 'user', title: 'マイルームへ'},
+                          {path: user_path(current_user), icon: 'user', title: 'マイルームへ'},
                         ]
 
           - nav_menus.each do |menu|

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -20,4 +20,5 @@
       .row
         - @user.posts.each do |post|
           .col-md-4.mb-3
-            == image_tag post.images.first.photo.url, size: '400x300', class: 'swiper-slide', alt: 'post img'
+            = link_to post_path(post) do
+              = image_tag post.images.first.photo.url(:thumb), size: '400x400', class: 'swiper-slide', alt: 'post img'


### PR DESCRIPTION
## 何をしたか
ユーザー詳細ページを作成しました。
ユーザー詳細ページにはユーザーの投稿の最初の画像が表示され、
画像からは各ポストに遷移することができます

ユーザーフォローボタンを作成した際に大枠を作ってしまったので、コミットは少なめです。