### PR TITLE
gem sidekiq の導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'popper_js'
 gem 'redis-rails'
 gem 'rails-i18n'
 gem 'sidekiq'
+gem 'sinatra'
 gem 'slim-rails'
 gem 'sorcery'
 

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'mini_magick'
 gem 'popper_js'
 gem 'redis-rails'
 gem 'rails-i18n'
+gem 'sidekiq'
 gem 'slim-rails'
 gem 'sorcery'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     config (3.0.0)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
+    connection_pool (2.2.3)
     counter_culture (2.7.0)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
@@ -317,6 +318,10 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sidekiq (6.2.0)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -401,6 +406,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (~> 5.0)
   selenium-webdriver
+  sidekiq
   slim-rails
   sorcery
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.3)
     nio4r (2.5.4)
     nokogiri (1.10.10)
@@ -227,6 +229,8 @@ GEM
     public_suffix (4.0.6)
     puma (3.12.6)
     rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -322,6 +326,11 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -407,6 +416,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   sidekiq
+  sinatra
   slim-rails
   sorcery
   spring

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,8 @@ module InstaClone
       g.helper false
       g.test_framework false
     end
+
+    config.active_job.queue_adapter = :sidekiq
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: 'redis://localhost:6379' }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: 'redis://localhost:6379' }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
 
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
+    mount Sidekiq::Web, at: '/sidekiq'
   end
 
   get 'login', to: 'user_sessions#new'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+:concurrency: 25
+:queues:
+  - default
+  - mailers


### PR DESCRIPTION
## 何をしたか
- gem sidekiq を導入して、メールジョブを非同期処理にし、サーバーのストップ・リセットなどでジョブが失われないようにしました

[Issue12 メールのジョブの永続化を実装](https://github.com/miketa-webprgr/TIL/blob/master/11_Rails_Intensive_Training/12_issue_note.md)

自分でまとめたノートはこちらです
[gem Sidekiqの導入](https://qiita.com/tanutanu/items/dabd550e3f969f72d64c)

###  タスク詳細
- gem sidekiq の導入
- sidekiq 設定ファイルの記載
- sinatraのインストール