### PR TITLE
ユーザーがメール受信設定を変えられるようにする

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
 
   def create
     @comment = current_user.comments.build(comment_params)
-    UserMailer.with(user_from: current_user, user_to: @comment.post.user, comment: @comment).comment_post.deliver_later if @comment.save
+    UserMailer.with(user_from: current_user, user_to: @comment.post.user, comment: @comment).comment_post.deliver_later if @comment.save && @comment.post.user.notification_on_comment?
   end
 
   def edit; end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -3,7 +3,7 @@ class LikesController < ApplicationController
 
   def create
     @post = Post.find(params[:post])
-    UserMailer.with(user_from: current_user, user_to: @post.user, post: @post).like_post.deliver_later if current_user.like(@post)
+    UserMailer.with(user_from: current_user, user_to: @post.user, post: @post).like_post.deliver_later if current_user.like(@post) && @post.user.notification_on_like?
   end
 
   def destroy

--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -1,0 +1,7 @@
+class Mypage::NotificationSettingsController < Mypage::BaseController
+  def edit
+  end
+
+  def update
+  end
+end

--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -6,9 +6,9 @@ class Mypage::NotificationSettingsController < Mypage::BaseController
   def update
     @user = User.find(current_user.id)
     if @user.update(notification_settings_params)
-      redirect_to edit_mypage_notification_setting_path, success: '設定を更新しました'
+      redirect_to edit_mypage_notification_setting_path, flash: { success: '設定を更新しました' }
     else
-      flas.now[:danger] = "設定の更新に失敗しました"
+      flash.now[:danger] = "設定の更新に失敗しました"
       render :edit
     end
   end

--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -1,7 +1,21 @@
 class Mypage::NotificationSettingsController < Mypage::BaseController
   def edit
+    @user = User.find(current_user.id)
   end
 
   def update
+    @user = User.find(current_user.id)
+    if @user.update(notification_settings_params)
+      redirect_to edit_mypage_notification_setting_path, success: '設定を更新しました'
+    else
+      flas.now[:danger] = "設定の更新に失敗しました"
+      render :edit
+    end
+  end
+
+  private
+
+  def notification_settings_params
+    params.require(:user).permit(:notification_on_comment, :notification_on_like, :notification_on_follow)
   end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -3,7 +3,7 @@ class RelationshipsController < ApplicationController
 
   def create
     @other_user = User.find(params[:follower])
-    UserMailer.with(user_from: current_user, user_to: @other_user).follow.deliver_later if current_user.follow(@other_user) && @user.notification_on_follow?
+    UserMailer.with(user_from: current_user, user_to: @other_user).follow.deliver_later if current_user.follow(@other_user) && @other_user.notification_on_follow?
   end
 
   def destroy

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -3,7 +3,7 @@ class RelationshipsController < ApplicationController
 
   def create
     @other_user = User.find(params[:follower])
-    UserMailer.with(user_from: current_user, user_to: @other_user).follow.deliver_later if current_user.follow(@other_user)
+    UserMailer.with(user_from: current_user, user_to: @other_user).follow.deliver_later if current_user.follow(@other_user) && @user.notification_on_follow?
   end
 
   def destroy

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,7 +4,7 @@
 #
 #  id           :bigint           not null, primary key
 #  action_type  :integer          not null
-#  read         :boolean          default(FALSE), not null
+#  read         :boolean          default("unread"), not null
 #  subject_type :string(255)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,14 +2,17 @@
 #
 # Table name: users
 #
-#  id               :bigint           not null, primary key
-#  avatar           :string(255)
-#  crypted_password :string(255)
-#  email            :string(255)      not null
-#  salt             :string(255)
-#  username         :string(255)      not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id                      :bigint           not null, primary key
+#  avatar                  :string(255)
+#  crypted_password        :string(255)
+#  email                   :string(255)      not null
+#  notification_on_comment :boolean          default(TRUE)
+#  notification_on_follow  :boolean          default(TRUE)
+#  notification_on_like    :boolean          default(TRUE)
+#  salt                    :string(255)
+#  username                :string(255)      not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 # Indexes
 #

--- a/app/views/mypage/accounts/edit.html.slim
+++ b/app/views/mypage/accounts/edit.html.slim
@@ -7,7 +7,7 @@
     - if current_user.avatar?
       = image_tag current_user.avatar.url, size: '100x100', class: 'rounded-circle', id: 'preview'
     - else
-      = image_tag 'default_avatar.png', size: '100x100', class: 'rounded-circle', id: 'preview'
+      = image_tag 'fallback/default_avatar.png', size: '100x100', class: 'rounded-circle', id: 'preview'
   .form-group
     = f.label :username, t('activerecord.models.users.username')
     = f.text_field :username, class: 'form-control'

--- a/app/views/mypage/activities/_commented_to_own_post.html.slim
+++ b/app/views/mypage/activities/_commented_to_own_post.html.slim
@@ -1,5 +1,5 @@
 = link_to read_activity_path(activity), class: "c-activity-list dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
-  - photo_url = activity.subject.user.avatar.present? ? activity.subject.user.avatar.url : 'default_avatar.png'
+  - photo_url = activity.subject.user.avatar.present? ? activity.subject.user.avatar.url : 'fallback/default_avatar.png'
   = image_tag photo_url, class: 'rounded-circle mr-1', size: '30x30'
   object
     = link_to activity.subject.user.username, user_path(activity.subject.user)

--- a/app/views/mypage/activities/_followd_me.html.slim
+++ b/app/views/mypage/activities/_followd_me.html.slim
@@ -1,5 +1,5 @@
 = link_to read_activity_path(activity), class: "c-activity-list dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
-  - photo_url = activity.subject.user.avatar.present? ? activity.subject.user.avatar.url : 'default_avatar.png'
+  - photo_url = activity.subject.user.avatar.present? ? activity.subject.user.avatar.url : 'fallback/default_avatar.png'
   = image_tag photo_url, class: 'rounded-circle mr-1', size: '30x30'
   object
     = link_to activity.subject.follower.username, user_path(activity.subject.follower)

--- a/app/views/mypage/activities/_followed_me.html.slim
+++ b/app/views/mypage/activities/_followed_me.html.slim
@@ -3,9 +3,6 @@
   = image_tag photo_url, class: 'rounded-circle mr-1', size: '30x30'
   object
     = link_to activity.subject.follower.username, user_path(activity.subject.follower)
-  | があなたを
-  object
-    =link_to '投稿', post_path(activity.subject.post)
-  | フォローしました
+  | があなたをフォローしました
   .text-right
     = l activity.created_at, format: :short

--- a/app/views/mypage/activities/_liked_to_own_post.html.slim
+++ b/app/views/mypage/activities/_liked_to_own_post.html.slim
@@ -1,5 +1,5 @@
 = link_to read_activity_path(activity), class: "c-activity-list dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
-  - photo_url = activity.subject.user.avatar.present? ? activity.subject.user.avatar.url : 'default_avatar.png'
+  - photo_url = activity.subject.user.avatar.present? ? activity.subject.user.avatar.url : 'fallback/default_avatar.png'
   = image_tag photo_url, class: 'rounded-circle mr-1', size: '30x30'
   object
     = link_to activity.subject.user.username, user_path(activity.subject.user)

--- a/app/views/mypage/notification_settings/edit.html.slim
+++ b/app/views/mypage/notification_settings/edit.html.slim
@@ -1,0 +1,1 @@
+spam editページ

--- a/app/views/mypage/notification_settings/edit.html.slim
+++ b/app/views/mypage/notification_settings/edit.html.slim
@@ -1,1 +1,15 @@
-spam editページ
+= form_with model: @user, url: mypage_notification_setting_path, method: :patch, local: true do |f|
+
+  .form-group
+    = f.check_box :notification_on_comment
+    = f.label :notification_on_comment, t('activerecord.models.users.notification_on_comment')
+
+  .form-group
+    = f.check_box :notification_on_like
+    = f.label :notification_on_like, t('activerecord.models.users.notification_on_like')
+
+  .form-group
+    = f.check_box :notification_on_follow
+    = f.label :notification_on_follow, t('activerecord.models.users.notification_on_follow')
+
+  = f.submit class: 'btn btn-primary btn-raised'

--- a/app/views/mypage/shared/_sidebar.html.slim
+++ b/app/views/mypage/shared/_sidebar.html.slim
@@ -6,3 +6,6 @@ nav
     li
       = link_to '通知一覧', mypage_activities_path
       hr
+    li
+      = link_to '通知設定', edit_mypage_notification_setting_path
+      hr

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,9 @@ ja:
       users:
         avatar: "アバター"
         email: "メールアドレス"
+        notification_on_comment: 'コメント時の通知メール'
+        notification_on_like: 'いいね時の通知メール'
+        notification_on_follow: 'フォロー時の通知メール'
         password: "パスワード"
         password_confirmation: "パスワード（確認）"
         username: "ユーザー名"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,5 +32,6 @@ Rails.application.routes.draw do
   namespace :mypage do
     resource :account, only: %i[edit update]
     resources :activities, only: %i[index]
+    resource :notification_setting, only: %i[edit update]
   end
 end

--- a/db/migrate/20210327092540_add_notification_settings_to_users.rb
+++ b/db/migrate/20210327092540_add_notification_settings_to_users.rb
@@ -1,0 +1,7 @@
+class AddNotificationSettingsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :notification_on_comment, :boolean, default: true
+    add_column :users, :notification_on_like, :boolean, default: true
+    add_column :users, :notification_on_follow, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_20_042159) do
+ActiveRecord::Schema.define(version: 2021_03_27_092540) do
 
   create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -79,6 +79,9 @@ ActiveRecord::Schema.define(version: 2021_02_20_042159) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "avatar"
+    t.boolean "notification_on_comment", default: true
+    t.boolean "notification_on_like", default: true
+    t.boolean "notification_on_follow", default: true
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## このプルリクの内容
ユーザーが、フォロー・コメント・いいね！をされた時に、メールを受け取るかどうかを選べるようにする機能の実装です。

[![Image from Gyazo](https://i.gyazo.com/098a6e17718a28da0276515f40bcb198.png)](https://gyazo.com/098a6e17718a28da0276515f40bcb198)

## 作り方
usersテーブルに、
- フォロー時に通知を受け取る
- コメント時に通知を受け取る
- いいね！時に通知を受け取る

の３つのboolean型カラムを追加して、デフォルトを `true` にする。
そして、メールの送信ロジックに、それらが `true` だった時にメールを送信する、という条件を追加する。

とても簡単でした♪